### PR TITLE
Pass received message information onward instead of only the payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ from asyncio_mqtt import Client
 async def log_filtered_messages(client, topic_filter):
     async with client.filtered_messages(topic_filter) as messages:
         async for message in messages:
-            print(f'[topic_filter="{topic_filter}"]: {message.decode()}')
+            print(f'[topic_filter="{topic_filter}"]: {message.payload.decode()}')
 
 async def log_unfiltered_messages(client):
     async with client.unfiltered_messages() as messages:
         async for message in messages:
-            print(f'[unfiltered]: {message.decode()}')
+            print(f'[unfiltered]: {message.payload.decode()}')
 
 async def main():
     async with Client('test.mosquitto.org') as client:

--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -133,7 +133,7 @@ class Client:
         # Callback for the underlying API
         def _put_in_queue(client, userdata, msg):
             try:
-                messages.put_nowait(msg.payload)
+                messages.put_nowait(msg)
             except asyncio.QueueFull:
                 MQTT_LOGGER.warning(f'[{log_context}] Message queue is full. Discarding message.')
         # The generator that we give to the caller


### PR DESCRIPTION
When using `unfiltered_messages` to receive all MQTT messages it would be useful if information about the message was provided instead of just the payload. This PR changes the implementation to pass on the instance of MQTTMessage from paho instead of only the payload of the message.

Fixes #2.