### PR TITLE
Fix future exception on disconnect

### DIFF
--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -47,7 +47,7 @@ class Client:
         if logger is None:
             logger = MQTT_LOGGER
         self._client.enable_logger(logger)
-        
+
         if username is not None and password is not None:
             self._client.username_pw_set(username=username, password=password)
 
@@ -140,7 +140,7 @@ class Client:
         Use queue_maxsize to restrict the queue size. If the queue is full,
         incoming messages will be discarded (and a warning is logged).
         If queue_maxsize is less than or equal to zero, the queue size is infinite.
-        
+
         Example use:
             async with client.filtered_messages('floors/+/humidity') as messages:
                 async for message in messages:
@@ -236,7 +236,7 @@ class Client:
             # However, if the callback doesn't get called (e.g., due to a
             # network error) we still need to remove the item from the dict.
             self._pending_calls.pop(mid, None)
-                
+
     def _on_connect(self, client, userdata, flags, rc, properties=None):
         if rc == mqtt.CONNACK_ACCEPTED:
             self._connected.set_result(rc)
@@ -320,7 +320,7 @@ class Client:
         # Early out if already disconnected...
         if self._disconnected.done():
             disc_exc = self._disconnected.exception()
-            if disc_exc is None:
+            if disc_exc is not None:
                 # ...by raising the error that caused the disconnect
                 raise disc_exc
             # ...by returning since the disconnect was intentional

--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -259,7 +259,7 @@ class Client:
         #   "[asyncio] Future exception was never retrieved"
         #
         # See also: https://docs.python.org/3/library/asyncio-dev.html#detect-never-retrieved-exceptions
-        if not self._connected.done():
+        if not self._connected.done() or self._connected.exception() is not None:
             return
         if rc == mqtt.MQTT_ERR_SUCCESS:
             self._disconnected.set_result(rc)


### PR DESCRIPTION
I'm testing this library to use with Home Assistant. I've written a client based on the advanced example in the readme.

It seems we're setting an exception on the `self._disconnected` `asyncio.Future` used in `_on_disconnect`, even though the future is never awaited if there's an exception in the connect flow.

Without this fix, when the connection is refused, I'm seeing:
```
2020-11-27 01:20:49,138 INFO (MainThread) [openzwavemqtt] Starting client.
2020-11-27 01:20:49,138 DEBUG (MainThread) [asyncio] Using selector: EpollSelector
2020-11-27 01:20:49,147 DEBUG (ThreadPoolExecutor-0_0) [paho.mqtt.client] Sending CONNECT (u0, p0, wr0, wq0, wf0, c1, k60) client_id=b'6SHLIyeUtZENAYM3p4xxFi'
2020-11-27 01:20:49,150 DEBUG (MainThread) [paho.mqtt.client] Received CONNACK (0, 5)
2020-11-27 01:20:49,150 ERROR (MainThread) [openzwavemqtt] MQTT error: [code:5] Connection refused: Not authorised. Reconnecting in 2 seconds
2020-11-27 01:20:51,153 ERROR (MainThread) [asyncio] Future exception was never retrieved
future: <Future finished exception=MqttCodeError('Unexpected disconnect')>
asyncio_mqtt.error.MqttCodeError: [code:5] Unexpected disconnect
2020-11-27 01:20:51,159 DEBUG (ThreadPoolExecutor-0_0) [paho.mqtt.client] Sending CONNECT (u0, p0, wr0, wq0, wf0, c1, k60) client_id=b'6SHLIyeUtZENAYM3p4xxFi'
2020-11-27 01:20:51,161 DEBUG (MainThread) [paho.mqtt.client] Received CONNACK (0, 5)
2020-11-27 01:20:51,162 ERROR (MainThread) [openzwavemqtt] MQTT error: [code:5] Connection refused: Not authorised. Reconnecting in 4 seconds
2020-11-27 01:20:55,296 DEBUG (ThreadPoolExecutor-0_0) [paho.mqtt.client] Sending CONNECT (u0, p0, wr0, wq0, wf0, c1, k60) client_id=b'6SHLIyeUtZENAYM3p4xxFi'
2020-11-27 01:20:55,301 DEBUG (MainThread) [paho.mqtt.client] Received CONNACK (0, 5)
2020-11-27 01:20:55,302 ERROR (MainThread) [openzwavemqtt] MQTT error: [code:5] Connection refused: Not authorised. Reconnecting in 8 seconds
^C2020-11-27 01:20:55,976 INFO (MainThread) [openzwavemqtt] Exiting client.
2020-11-27 01:20:55,982 ERROR (MainThread) [asyncio] Future exception was never retrieved
future: <Future finished exception=MqttCodeError('Unexpected disconnect')>
asyncio_mqtt.error.MqttCodeError: [code:5] Unexpected disconnect
2020-11-27 01:20:55,983 ERROR (MainThread) [asyncio] Future exception was never retrieved
future: <Future finished exception=MqttCodeError('Unexpected disconnect')>
asyncio_mqtt.error.MqttCodeError: [code:5] Unexpected disconnect
```

With this fix:
```
2020-11-27 01:20:30,700 INFO (MainThread) [openzwavemqtt] Starting client.
2020-11-27 01:20:30,700 DEBUG (MainThread) [asyncio] Using selector: EpollSelector
2020-11-27 01:20:30,709 DEBUG (ThreadPoolExecutor-0_0) [paho.mqtt.client] Sending CONNECT (u0, p0, wr0, wq0, wf0, c1, k60) client_id=b'1c0Jnihm0DyAfyK4ETcfXp'
2020-11-27 01:20:30,712 DEBUG (MainThread) [paho.mqtt.client] Received CONNACK (0, 5)
2020-11-27 01:20:30,713 ERROR (MainThread) [openzwavemqtt] MQTT error: [code:5] Connection refused: Not authorised. Reconnecting in 2 seconds
2020-11-27 01:20:32,722 DEBUG (ThreadPoolExecutor-0_0) [paho.mqtt.client] Sending CONNECT (u0, p0, wr0, wq0, wf0, c1, k60) client_id=b'1c0Jnihm0DyAfyK4ETcfXp'
2020-11-27 01:20:32,725 DEBUG (MainThread) [paho.mqtt.client] Received CONNACK (0, 5)
2020-11-27 01:20:32,725 ERROR (MainThread) [openzwavemqtt] MQTT error: [code:5] Connection refused: Not authorised. Reconnecting in 4 seconds
2020-11-27 01:20:36,731 DEBUG (ThreadPoolExecutor-0_0) [paho.mqtt.client] Sending CONNECT (u0, p0, wr0, wq0, wf0, c1, k60) client_id=b'1c0Jnihm0DyAfyK4ETcfXp'
2020-11-27 01:20:36,734 DEBUG (MainThread) [paho.mqtt.client] Received CONNACK (0, 5)
2020-11-27 01:20:36,735 ERROR (MainThread) [openzwavemqtt] MQTT error: [code:5] Connection refused: Not authorised. Reconnecting in 8 seconds
^C2020-11-27 01:20:37,383 INFO (MainThread) [openzwavemqtt] Exiting client.
```