### PR TITLE
Check that _misc_task is not None before trying to cancel it.

### DIFF
--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -304,8 +304,9 @@ class Client:
 
     def _on_socket_close(self, client, userdata, sock):
         self._loop.remove_reader(sock.fileno())
-        with suppress(asyncio.CancelledError):
-            self._misc_task.cancel()
+        if self._misc_task is not None:
+            with suppress(asyncio.CancelledError):
+                self._misc_task.cancel()
 
     def _on_socket_register_write(self, client, userdata, sock):
         def cb():


### PR DESCRIPTION
In #39 there's a second exception caused by `self._mqtt_task` being `None` when we try to cancel it. Since it's initialised as `None`, we shouldn't assume that it's not.

This is also something that would need to be fixed once type hints are added.