### PR TITLE
Fix python3.6 compatibility

### DIFF
--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -162,7 +162,12 @@ class Client:
 
     async def connect(self, *, timeout: int = 10) -> None:
         try:
-            loop = asyncio.get_running_loop()
+            # get_running_loop is preferred, but only available in python>=3.7
+            try:
+                loop = asyncio.get_running_loop()
+            except AttributeError:
+                loop = asyncio.get_event_loop()
+
             # [3] Run connect() within an executor thread, since it blocks on socket
             # connection for up to `keepalive` seconds: https://git.io/Jt5Yc
             await loop.run_in_executor(

--- a/tests/reconnect.py
+++ b/tests/reconnect.py
@@ -38,7 +38,7 @@ def main():
         format="%(asctime)s %(levelname)s %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
-    asyncio.run(asyncio.wait([test(), tick()]))
+    asyncio.get_event_loop().run_until_complete(asyncio.wait([test(), tick()]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The library currently uses methods like ```get_running_loop()```, which are only available in python>=3.7
This PR fixes that.


Fixes the downstream-issue https://github.com/flyte/mqtt-io/issues/192