### PR TITLE
Improve cleanup when socket is invalid

### DIFF
--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -476,8 +476,11 @@ class Client:
     def _on_socket_close(
         self, client: mqtt.Client, userdata: Any, sock: socket.socket
     ) -> None:
-        self._loop.remove_reader(sock.fileno())
-        if self._misc_task is not None:
+
+        fileno = sock.fileno()
+        if fileno > -1:
+            self._loop.remove_reader(fileno)
+        if self._misc_task is not None and not self._misc_task.done():
             with suppress(asyncio.CancelledError):
                 self._misc_task.cancel()
 


### PR DESCRIPTION
Remove Asyncio loop reader for a socket, when its file number is valid as `socket.fileno` can return -1, see https://docs.python.org/3/library/socket.html#socket.socket.fileno.

This can happen because creation of socket can be delayed due to sleep  statements in Client._misc_loop method.

Also, cancel misc task only when it is not done.