### PR TITLE
Added a new parameter for configuring socket connection.

### DIFF
--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -88,6 +88,13 @@ class Client:
         clean_start: bool = mqtt.MQTT_CLEAN_START_FIRST_ONLY,
         properties: Optional[Properties] = None,
         message_retry_set: int = 20,
+        # By default, in order to optimize the transmission of small data packets,
+        # the send buffer size is set to 2048 bytes. To transfer large data packets (>50MB),
+        # it is recommended to increase the buffer value.
+        # It is also possible to set all possible socket settings.
+        # See https://docs.python.org/3/library/socket.html#socket.socket.setsockopt for more information.
+        # If the socket_options is None, then the system defaults are used.
+        socket_options: Optional[Tuple[int, int, Union[int, bytes]]] = (socket.SOL_SOCKET, socket.SO_SNDBUF, 2048),
     ):
         self._hostname = hostname
         self._port = port
@@ -143,6 +150,7 @@ class Client:
             )
 
         self._client.message_retry_set(message_retry_set)
+        self._socket_options = socket_options
 
     @property
     def id(self) -> str:
@@ -179,7 +187,8 @@ class Client:
                 self._clean_start, self._properties
             )
             client_socket = self._client.socket()
-            _set_client_socket_defaults(client_socket)
+            if self._socket_options is not None:
+                _set_client_socket_defaults(client_socket, self._socket_options)
         # paho.mqtt.Client.connect may raise one of several exceptions.
         # We convert all of them to the common MqttError for user convenience.
         # See: https://github.com/eclipse/paho.mqtt.python/blob/v1.5.0/src/paho/mqtt/client.py#L1770
@@ -542,7 +551,8 @@ class Client:
 _PahoSocket = Union[socket.socket, mqtt.WebsocketWrapper]
 
 
-def _set_client_socket_defaults(client_socket: Optional[_PahoSocket]) -> None:
+def _set_client_socket_defaults(client_socket: Optional[_PahoSocket],
+                                socket_param: Optional[Tuple[int, int, Union[int, bytes]]]) -> None:
     # Note that socket may be None if, e.g., the username and
     # password combination didn't work. In this case, we return early.
     if client_socket is None:
@@ -553,4 +563,4 @@ def _set_client_socket_defaults(client_socket: Optional[_PahoSocket]) -> None:
         return
     # At this point, we know that we got an actual socket. We change
     # some of the default options.
-    client_socket.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 2048)
+    client_socket.setsockopt(*socket_param)

--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -87,6 +87,7 @@ class Client:
         bind_port: int = 0,
         clean_start: bool = mqtt.MQTT_CLEAN_START_FIRST_ONLY,
         properties: Optional[Properties] = None,
+        message_retry_set: int = 20,
     ):
         self._hostname = hostname
         self._port = port
@@ -140,6 +141,8 @@ class Client:
             self._client.will_set(
                 will.topic, will.payload, will.qos, will.retain, will.properties
             )
+
+        self._client.message_retry_set(message_retry_set)
 
     @property
     def id(self) -> str:


### PR DESCRIPTION
From https://github.com/sbtinstruments/asyncio-mqtt/issues/70 issue.

        # By default, in order to optimize the transmission of small data packets,
        # the send buffer size is set to 2048 bytes. To transfer large data packets (>50MB),
        # it is recommended to increase the buffer value.
        # It is also possible to set all possible socket settings.
        # See https://docs.python.org/3/library/socket.html#socket.socket.setsockopt for more information.
        # If the socket_options is None, then the system defaults are used.