### PR TITLE
Fix typing, mostly related to async_generator

### DIFF
--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -24,13 +24,14 @@ from typing import (
     AsyncContextManager,
     TypeVar,
 )
-from typing_extensions import ParamSpec
+
 
 
 try:
     from contextlib import asynccontextmanager
 except ImportError:
     from async_generator import asynccontextmanager as _asynccontextmanager # type: ignore
+    from typing_extensions import ParamSpec
     _P = ParamSpec('_P')
     _T = TypeVar('_T')
     def asynccontextmanager(func: Callable[_P, AsyncIterator[_T]]) -> Callable[_P, AsyncContextManager[_T]]: # type: ignore

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,6 @@ setup(
     install_requires=[
         "paho-mqtt>=1.6.0",
         "async_generator;python_version<'3.7'",
+        "typing_extensions;python_version<'3.7'"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 with open("asyncio_mqtt/version.py", "r") as f:
     exec(f.read())
 
-with open("README.md", "r") as readme_file:
+with open("README.md", "r", encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
 setup(


### PR DESCRIPTION
While running the "advanced" example from the readme with pyright, i noticed it was alerting me to some typing issues, relating to asynccontextmanager and `Client.__aexit__`.


<details>
  <summary>Pyright errors</summary>

```
Argument of type "Client" cannot be assigned to parameter "cm" of type "AsyncContextManager[_T@enter_async_context]" in function "enter_async_context"
  "Client" is incompatible with protocol "AsyncContextManager[_T@enter_async_context]"
    "__aexit__" is an incompatible type
      Type "(exc_type: Type[Exception], exc: Exception, tb: TracebackType) -> Coroutine[Any, Any, None]" cannot be assigned to type "(__exc_type: Type[BaseException] | None, __exc_value: BaseException | None, __traceback: TracebackType | None) -> Awaitable[bool | None]"
        Parameter 1: type "Type[BaseException] | None" cannot be assigned to type "Type[Exception]"
          Type "Type[BaseException] | None" cannot be assigned to type "Type[Exception]"
        Parameter 2: type "BaseException | None" cannot be assigned to type "Exception"
          Type "BaseException | None" cannot be assigned to type "Exception"
        Parameter 3: type "TracebackType | None" cannot be assigned to type "TracebackType"
```
```
Argument of type "AsyncIterator[AsyncGenerator[MQTTMessage, None]]" cannot be assigned to parameter "cm" of type "AsyncContextManager[_T@enter_async_context]" in function "enter_async_context"
  "AsyncIterator[AsyncGenerator[MQTTMessage, None]]" is incompatible with protocol "AsyncContextManager[_T@enter_async_context]"
    "__aenter__" is not present
    "__aexit__" is not present
```
```
Argument of type "AsyncIterator[AsyncGenerator[MQTTMessage, None]]" cannot be assigned to parameter "cm" of type "AsyncContextManager[_T@enter_async_context]" in function "enter_async_context"
  "AsyncIterator[AsyncGenerator[MQTTMessage, None]]" is incompatible with protocol "AsyncContextManager[_T@enter_async_context]"
    "__aenter__" is not present
    "__aexit__" is not present
```
</details>

The issue with `Client.__aexit__` was simple, the arguments were missing the `Optional[]` around their type hint, and also need to use `BaseException` instead of `Exception`.

After a LOT of time trying to figure out what the issue wth asynccontextmanager was, i noticed that the compatibility import `async_generator` was missing type information, which caused pyright to fail at inferring the `AsyncContextManager` type for `Client.filtered_messages` and `Client.unfiltered_messages`. 

I solved this by redefining the asynccontextmanager imported from `async_generator` with the proper typehints, and ignoring the type issues on those lines. This could potentially be moved to a type stub, though im not very comfortable working with them yet.

After these changes there are no more issues running pyright on the advanced readme example.  
MyPy still throws a few errors relating to SocketOption, but this is behaviour that has not changed.
I have tested running the advanced readme example on python 3.6 and with modifications to the example due to missing features it runs fine.