### PR TITLE
Pyright reports false positive error with `asynccontextmanager`

### DIFF
--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import socket
 import ssl
+import sys
 from contextlib import contextmanager, suppress
 from enum import IntEnum
 from types import TracebackType
@@ -24,9 +25,11 @@ from typing import (
 )
 
 
-try:
+
+# asynccontextmanager exists in contextlib in python3.7 and later.
+if sys.version_info >= (3, 7)
     from contextlib import asynccontextmanager
-except ImportError:
+else:
     from async_generator import asynccontextmanager  # type: ignore
 
 import paho.mqtt.client as mqtt  # type: ignore


### PR DESCRIPTION
Pyright gets confused and will give you error messages like this:
```
error: Object of type "AsyncIterator[AsyncGenerator[...]]" cannot be used with "with" because it does not implement __aenter__ (reportGeneralTypeIssues)
error: Object of type "AsyncIterator[AsyncGenerator[...]]" cannot be used with "with" because it does not implement __aexit__ (reportGeneralTypeIssues)
```
For code like this:
```python
async with Client("test.mosquitto.org") as client:
    async with client.filtered_messages("floors/+/humidity") as messages:
        await client.subscribe("floors/#")
        async for message in messages:
            print(message.payload.decode())
```

This change statically checks against `sys.version_info` for the right version, which Pyright understands.

For additional discussion, see https://github.com/encode/httpx/discussions/1829.