### PR TITLE
Fix typing error of `__aexit__`

### DIFF
--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -536,7 +536,10 @@ class Client:
         return self
 
     async def __aexit__(
-        self, exc_type: Optional[Type[BaseException]], exc: Optional[BaseException], tb: Optional[TracebackType]
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Optional[TracebackType],
     ) -> None:
         """Disconnect from the broker."""
         # Early out if already disconnected...


### PR DESCRIPTION
This should take `Optional` types for `exc_type`, `exc`, and `tb`, as
well as taking a `BaseException` instead of an `Exception`.

Fixes #98