### PR TITLE
Add backpressure mechanism to limit the number of concurrent outgoing calls

### DIFF
--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -233,7 +233,7 @@ class Client:
     # 3.10). See: https://docs.python.org/3/library/contextlib.html#contextlib.nullcontext
     def _outgoing_call(self, func: Callable) -> Callable[..., Awaitable]:
         @functools.wraps(func)
-        async def decorated(*args: Any, **kwargs: Any) -> None:
+        async def decorated(*args: Any, **kwargs: Any) -> Union[None, int]:
             if not self._outgoing_calls_sem:
                 return await func(*args, **kwargs)
 

--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -64,8 +64,6 @@ class ProtocolVersion(IntEnum):
 # TODO: This should be a (frozen) dataclass (from Python 3.7)
 # when we drop Python 3.6 support
 class Will:
-
-    OutgoingType = TypeVar("OutgoingType", None, int)
     def __init__(
         self,
         topic: str,

--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -48,6 +48,8 @@ from .types import PayloadType, T
 MQTT_LOGGER = logging.getLogger("mqtt")
 MQTT_LOGGER.setLevel(logging.WARNING)
 
+OutgoingType = TypeVar("OutgoingType", None, int)
+
 
 class ProtocolVersion(IntEnum):
     """
@@ -62,6 +64,8 @@ class ProtocolVersion(IntEnum):
 # TODO: This should be a (frozen) dataclass (from Python 3.7)
 # when we drop Python 3.6 support
 class Will:
+
+    OutgoingType = TypeVar("OutgoingType", None, int)
     def __init__(
         self,
         topic: str,
@@ -233,7 +237,7 @@ class Client:
     # 3.10). See: https://docs.python.org/3/library/contextlib.html#contextlib.nullcontext
     def _outgoing_call(self, func: Callable) -> Callable[..., Awaitable]:
         @functools.wraps(func)
-        async def decorated(*args: Any, **kwargs: Any) -> Union[None, int]:
+        async def decorated(*args: Any, **kwargs: Any) -> OutgoingType:
             if not self._outgoing_calls_sem:
                 return await func(*args, **kwargs)
 

--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -48,7 +48,7 @@ from .types import PayloadType, T
 MQTT_LOGGER = logging.getLogger("mqtt")
 MQTT_LOGGER.setLevel(logging.WARNING)
 
-OutgoingType = TypeVar("OutgoingType", None, int)
+T = TypeVar("T")
 
 
 class ProtocolVersion(IntEnum):
@@ -235,9 +235,9 @@ class Client:
     # TODO: Simplify the logic that surrounds `self._outgoing_calls_sem` with
     # `nullcontext` when we support Python 3.10 (`nullcontext` becomes async-aware in
     # 3.10). See: https://docs.python.org/3/library/contextlib.html#contextlib.nullcontext
-    def _outgoing_call(self, func: Callable) -> Callable[..., Awaitable]:
+    def _outgoing_call(self, func: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]:
         @functools.wraps(func)
-        async def decorated(*args: Any, **kwargs: Any) -> OutgoingType:
+        async def decorated(*args: Any, **kwargs: Any) -> T:
             if not self._outgoing_calls_sem:
                 return await func(*args, **kwargs)
 


### PR DESCRIPTION
This PR applies a backpressure mechanism so that extremely chatty clients don't add congestion to the server. The mechanism is controlled with a `max_concurrent_outgoing_calls` parameter that can be applied to the client during instantiation:

* A `max_concurrent_outgoing_calls` value of `None` means that no back pressure is applied
* A `max_concurrent_outgoing_calls` value with a positive `int` indicates that no more than `max_concurrent_outgoing_calls` outgoing calls can happen at any given time.

Fixes https://github.com/sbtinstruments/asyncio-mqtt/issues/29

@frederikaalund Some comments for your review and consideration:

* As discussed, the fact that `max_concurrent_outgoing_calls` can be `None` (and is so by default) should retain backward compatibility.
* I didn't see any other spots in the README where specific functionality is shown via example; let me know if you think one is warranted here.
* I didn't apply any linting/styling since I couldn't determine whether a standard was already used. I did endeavor to follow the existing standard for type hinting.
* I didn't add any tests for this since the library as a whole doesn't seem to carry many; let me know if you would prefer I add some.