### PR TITLE
client: Fix thread safety in socket close callback

### DIFF
--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -534,8 +534,7 @@ class Client:
         if fileno > -1:
             self._loop.remove_reader(fileno)
         if self._misc_task is not None and not self._misc_task.done():
-            with suppress(asyncio.CancelledError):
-                self._misc_task.cancel()
+            self._loop.call_soon_threadsafe(self._misc_task.cancel)
 
     def _on_socket_register_write(
         self, client: mqtt.Client, userdata: Any, sock: socket.socket


### PR DESCRIPTION
The `_on_socket_close` method can be called from a different thread than the
running event loop if an error occurs while the connection is being
established.  This can happen, for example, if the TCP connection is
established, but the TLS or WebSocket handshake fails.  It is not safe to
cancel the task from another thread.  Instead, the cancellation should be
scheduled to run as soon as the event loop is idle.