### PR TITLE
Fix race conditions that may cause `InvalidStateError`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing so far.
+### Fixed
+
+- Fix race conditions that may cause `InvalidStateError`. 
 
 ## [0.12.1] - 2022-01-19
 


### PR DESCRIPTION
This fixes https://github.com/sbtinstruments/asyncio-mqtt/issues/122