### PR TITLE
use tls_set() in addition to tls_context

### DIFF
--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -87,6 +87,7 @@ class Will:
 class TLSParameters:
     def __init__(
         self,
+        *,
         ca_certs: Optional[str] = None,
         certfile: Optional[str] = None,
         keyfile: Optional[str] = None,

--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -139,7 +139,7 @@ class Client:
         logger: Optional[logging.Logger] = None,
         client_id: Optional[str] = None,
         tls_context: Optional[ssl.SSLContext] = None,
-        tls_set_params: Optional[TLSParameters] = None,
+        tls_params: Optional[TLSParameters] = None,
         protocol: Optional[ProtocolVersion] = None,
         will: Optional[Will] = None,
         clean_session: Optional[bool] = None,
@@ -212,14 +212,14 @@ class Client:
         if tls_context is not None:
             self._client.tls_set_context(tls_context)
         
-        if tls_set_params is not None:
-            self._client.tls_set(ca_certs= tls_set_params.ca_certs,
-                                 certfile= tls_set_params.certfile,
-                                 keyfile= tls_set_params.keyfile,
-                                 cert_reqs= tls_set_params.cert_reqs,
-                                 tls_version= tls_set_params.tls_version,
-                                 ciphers= tls_set_params.ciphers,
-                                 keyfile_password= tls_set_params.keyfile_password)
+        if tls_params is not None:
+            self._client.tls_set(ca_certs= tls_params.ca_certs,
+                                 certfile= tls_params.certfile,
+                                 keyfile= tls_params.keyfile,
+                                 cert_reqs= tls_params.cert_reqs,
+                                 tls_version= tls_params.tls_version,
+                                 ciphers= tls_params.ciphers,
+                                 keyfile_password= tls_params.keyfile_password)
 
         if websocket_path is not None or websocket_headers is not None:
             self._client.ws_set_options(

--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -90,8 +90,8 @@ class TLSParameters:
         ca_certs: Optional[str] = None,
         certfile: Optional[str] = None,
         keyfile: Optional[str] = None,
-        cert_reqs: Optional[ssl.VerifyMode] = ssl.CERT_REQUIRED,
-        tls_version: Optional[ssl._SSLMethod]= ssl.PROTOCOL_TLSv1_2,
+        cert_reqs: Optional[ssl.VerifyMode] = None,
+        tls_version: Optional[ssl._SSLMethod]= None,
         ciphers: Optional[str] = None,
         keyfile_password: Optional[str] = None       
     ):

--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -83,6 +83,27 @@ class Will:
         self.retain = retain
         self.properties = properties
 
+# TLS set parameter class
+class TLSParameters:
+    def __init__(
+        self,
+        ca_certs: Optional[str] = None,
+        certfile: Optional[str] = None,
+        keyfile: Optional[str] = None,
+        cert_reqs: Optional[ssl.VerifyMode] = ssl.CERT_REQUIRED,
+        tls_version: Optional[ssl._SSLMethod]= ssl.PROTOCOL_TLSv1_2,
+        ciphers: Optional[str] = None,
+        keyfile_password: Optional[str] = None       
+    ):
+        self.ca_certs = ca_certs
+        self.certfile = certfile
+        self.keyfile = keyfile
+        self.cert_reqs = cert_reqs
+        self.tls_version = tls_version
+        self.ciphers = ciphers
+        self.keyfile_password = keyfile_password 
+        
+
 
 # See the overloads of `socket.setsockopt` for details.
 SocketOption = Union[
@@ -117,6 +138,7 @@ class Client:
         logger: Optional[logging.Logger] = None,
         client_id: Optional[str] = None,
         tls_context: Optional[ssl.SSLContext] = None,
+        tls_set_params: Optional[TLSParameters] = None,
         protocol: Optional[ProtocolVersion] = None,
         will: Optional[Will] = None,
         clean_session: Optional[bool] = None,
@@ -188,6 +210,15 @@ class Client:
 
         if tls_context is not None:
             self._client.tls_set_context(tls_context)
+        
+        if tls_set_params is not None:
+            self._client.tls_set(ca_certs= tls_set_params.ca_certs,
+                                 certfile= tls_set_params.certfile,
+                                 keyfile= tls_set_params.keyfile,
+                                 cert_reqs= tls_set_params.cert_reqs,
+                                 tls_version= tls_set_params.tls_version,
+                                 ciphers= tls_set_params.ciphers,
+                                 keyfile_password= tls_set_params.keyfile_password)
 
         if websocket_path is not None or websocket_headers is not None:
             self._client.ws_set_options(


### PR DESCRIPTION
I use the comments about the design of adding `tls_set` to `asyncio-mqtt` from https://github.com/sbtinstruments/asyncio-mqtt/issues/14#issuecomment-671780413 and try to implement in the light of that. 

My implementation allows the use of a `TLSParameters` object to invoke `tls_set()` function of paho-mqtt client in asyncio-mqtt. Let me know if it makes sense. I would also like some pointers in regards to testing this 