### PR TITLE
paho.mqtt.proxy_set() - support

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ There is only a single dependency:
 ## Note for Windows Users
 
 Since Python 3.8, the default asyncio event loop is the `ProactorEventLoop`. Said loop [doesn't support the `add_reader` method](https://docs.python.org/3/library/asyncio-platforms.html#windows) that is required by asyncio-mqtt. To use asyncio-mqtt, please switch to an event loop that supports the `add_reader` method such as the built-in `SelectorEventLoop`. E.g:
-```
+```python
 # Change to the "Selector" event loop
 asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 # Run your async application as usual

--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -104,7 +104,25 @@ class TLSParameters:
         self.ciphers = ciphers
         self.keyfile_password = keyfile_password 
         
-
+# Proxy parameters class 
+class ProxySettings:
+    def __init__(
+        self,
+        *, 
+        proxy_type: int = None,
+        proxy_addr: str = None,
+        proxy_rdns: Optional[bool] = True,
+        proxy_username: Optional[str] = None,
+        proxy_password: Optional[str] = None
+    ):
+        self.proxy_args = {
+            "proxy_type" : proxy_type,
+            "proxy_addr" : proxy_addr,
+            "proxy_rdns" : proxy_rdns,
+            "proxy_username" : proxy_username,
+            "proxy_password" : proxy_password 
+        }
+        
 
 # See the overloads of `socket.setsockopt` for details.
 SocketOption = Union[
@@ -140,6 +158,7 @@ class Client:
         client_id: Optional[str] = None,
         tls_context: Optional[ssl.SSLContext] = None,
         tls_params: Optional[TLSParameters] = None,
+        proxy: Optional[ProxySettings] = None,
         protocol: Optional[ProtocolVersion] = None,
         will: Optional[Will] = None,
         clean_session: Optional[bool] = None,
@@ -220,6 +239,9 @@ class Client:
                                  tls_version= tls_params.tls_version,
                                  ciphers= tls_params.ciphers,
                                  keyfile_password= tls_params.keyfile_password)
+        
+        if proxy is not None:
+            self._client.proxy_set(**proxy.proxy_args)    
 
         if websocket_path is not None or websocket_headers is not None:
             self._client.ws_set_options(

--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -87,6 +87,7 @@ class Will:
 class TLSParameters:
     def __init__(
         self,
+        *,
         ca_certs: Optional[str] = None,
         certfile: Optional[str] = None,
         keyfile: Optional[str] = None,

--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -139,7 +139,7 @@ class Client:
         logger: Optional[logging.Logger] = None,
         client_id: Optional[str] = None,
         tls_context: Optional[ssl.SSLContext] = None,
-        tls_set_params: Optional[TLSParameters] = None,
+        tls_params: Optional[TLSParameters] = None,
         protocol: Optional[ProtocolVersion] = None,
         will: Optional[Will] = None,
         clean_session: Optional[bool] = None,
@@ -212,14 +212,14 @@ class Client:
         if tls_context is not None:
             self._client.tls_set_context(tls_context)
         
-        if tls_set_params is not None:
-            self._client.tls_set(ca_certs= tls_set_params.ca_certs,
-                                 certfile= tls_set_params.certfile,
-                                 keyfile= tls_set_params.keyfile,
-                                 cert_reqs= tls_set_params.cert_reqs,
-                                 tls_version= tls_set_params.tls_version,
-                                 ciphers= tls_set_params.ciphers,
-                                 keyfile_password= tls_set_params.keyfile_password)
+        if tls_params is not None:
+            self._client.tls_set(ca_certs= tls_params.ca_certs,
+                                 certfile= tls_params.certfile,
+                                 keyfile= tls_params.keyfile,
+                                 cert_reqs= tls_params.cert_reqs,
+                                 tls_version= tls_params.tls_version,
+                                 ciphers= tls_params.ciphers,
+                                 keyfile_password= tls_params.keyfile_password)
 
         if websocket_path is not None or websocket_headers is not None:
             self._client.ws_set_options(

--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -90,8 +90,8 @@ class TLSParameters:
         ca_certs: Optional[str] = None,
         certfile: Optional[str] = None,
         keyfile: Optional[str] = None,
-        cert_reqs: Optional[ssl.VerifyMode] = ssl.CERT_REQUIRED,
-        tls_version: Optional[ssl._SSLMethod]= ssl.PROTOCOL_TLSv1_2,
+        cert_reqs: Optional[ssl.VerifyMode] = None,
+        tls_version: Optional[ssl._SSLMethod]= None,
         ciphers: Optional[str] = None,
         keyfile_password: Optional[str] = None       
     ):

--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -109,8 +109,8 @@ class ProxySettings:
     def __init__(
         self,
         *, 
-        proxy_type: int = None,
-        proxy_addr: str = None,
+        proxy_type: int,
+        proxy_addr: str,
         proxy_rdns: Optional[bool] = True,
         proxy_username: Optional[str] = None,
         proxy_password: Optional[str] = None

--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -83,6 +83,27 @@ class Will:
         self.retain = retain
         self.properties = properties
 
+# TLS set parameter class
+class TLSParameters:
+    def __init__(
+        self,
+        ca_certs: Optional[str] = None,
+        certfile: Optional[str] = None,
+        keyfile: Optional[str] = None,
+        cert_reqs: Optional[ssl.VerifyMode] = ssl.CERT_REQUIRED,
+        tls_version: Optional[ssl._SSLMethod]= ssl.PROTOCOL_TLSv1_2,
+        ciphers: Optional[str] = None,
+        keyfile_password: Optional[str] = None       
+    ):
+        self.ca_certs = ca_certs
+        self.certfile = certfile
+        self.keyfile = keyfile
+        self.cert_reqs = cert_reqs
+        self.tls_version = tls_version
+        self.ciphers = ciphers
+        self.keyfile_password = keyfile_password 
+        
+
 
 # See the overloads of `socket.setsockopt` for details.
 SocketOption = Union[
@@ -117,6 +138,7 @@ class Client:
         logger: Optional[logging.Logger] = None,
         client_id: Optional[str] = None,
         tls_context: Optional[ssl.SSLContext] = None,
+        tls_set_params: Optional[TLSParameters] = None,
         protocol: Optional[ProtocolVersion] = None,
         will: Optional[Will] = None,
         clean_session: Optional[bool] = None,
@@ -188,6 +210,15 @@ class Client:
 
         if tls_context is not None:
             self._client.tls_set_context(tls_context)
+        
+        if tls_set_params is not None:
+            self._client.tls_set(ca_certs= tls_set_params.ca_certs,
+                                 certfile= tls_set_params.certfile,
+                                 keyfile= tls_set_params.keyfile,
+                                 cert_reqs= tls_set_params.cert_reqs,
+                                 tls_version= tls_set_params.tls_version,
+                                 ciphers= tls_set_params.ciphers,
+                                 keyfile_password= tls_set_params.keyfile_password)
 
         if websocket_path is not None or websocket_headers is not None:
             self._client.ws_set_options(


### PR DESCRIPTION
This commit adds the functionality of paho-mqtt's `proxy_set()` to asyncio-mqtt