### PR TITLE
Fix missing ProtocolVersion import in TLS configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 Write code like this:
 
-
 ##### Subscriber
+
 ```python
 async with Client("test.mosquitto.org") as client:
     async with client.filtered_messages("floors/+/humidity") as messages:
@@ -17,6 +17,7 @@ async with Client("test.mosquitto.org") as client:
 ```
 
 ##### Publisher
+
 ```python
 async with Client("test.mosquitto.org") as client:
     message = "10%"
@@ -26,16 +27,14 @@ async with Client("test.mosquitto.org") as client:
           )
 ```
 
-
-
 asyncio-mqtt combines the stability of the time-proven [paho-mqtt](https://github.com/eclipse/paho.mqtt.python) library with a modern, asyncio-based interface.
 
-* No more callbacks! 👍
-* No more return codes (welcome to the `MqttError`)
-* Graceful disconnection (forget about `on_unsubscribe`, `on_disconnect`, etc.)
-* Compatible with `async` code
-* Fully type-hinted
-* Did we mention no more callbacks?
+- No more callbacks! 👍
+- No more return codes (welcome to the `MqttError`)
+- Graceful disconnection (forget about `on_unsubscribe`, `on_disconnect`, etc.)
+- Compatible with `async` code
+- Fully type-hinted
+- Did we mention no more callbacks?
 
 The whole thing is less than [700 lines of code](https://github.com/sbtinstruments/asyncio-mqtt/blob/master/asyncio_mqtt/client.py).
 
@@ -144,24 +143,25 @@ async def main():
 
 asyncio.run(main())
 ```
+
 ## TLS configuration for MQTT client
 
 asyncio-mqtt also exposes paho-mqtt's `tls_set` functionality for the users. The following minimal example explains how to enable SSL/TLS support for asyncio-mqtt client
 
 ```python
 import ssl
-from asyncio_mqtt import Client, TLSParameters
+from asyncio_mqtt import Client, TLSParameters, ProtocolVersion
 
 """
 ca_certs          : a string path to the Certificate Authority certificate files
                     that are to be treated as trusted by this client
-certfile & keyfile: strings pointing to the PEM encoded client certificate and 
+certfile & keyfile: strings pointing to the PEM encoded client certificate and
                     private keys respectively
-cert_reqs         : allows the certificate requirements that the client imposes on 
-                    the broker to be changed. By default this is ssl.CERT_REQUIRED  
-tls_version       : allows the version of the SSL/TLS protocol used to be specified. 
+cert_reqs         : allows the certificate requirements that the client imposes on
+                    the broker to be changed. By default this is ssl.CERT_REQUIRED
+tls_version       : allows the version of the SSL/TLS protocol used to be specified.
                     By default TLS v1 is used
-ciphers           : string specifying which encryption ciphers are allowable for this 
+ciphers           : string specifying which encryption ciphers are allowable for this
                     connection, or None to use the defaults
 keyfile_password  : if either certfile or keyfile is encrypted and needs a password to
                     decrypt it, then this can be passed using the keyfile_password
@@ -227,29 +227,29 @@ async with Client(
 
 Is asyncio-mqtt not what you are looking for? Try another client:
 
- * [hbmqtt](https://github.com/beerfactory/hbmqtt) - Own protocol implementation. Includes a broker.  
-   ![GitHub stars](https://img.shields.io/github/stars/beerfactory/hbmqtt)
-   ![license](https://img.shields.io/github/license/beerfactory/hbmqtt)
- * [gmqtt](https://github.com/wialon/gmqtt) - Own protocol implementation. No dependencies.  
-   ![GitHub stars](https://img.shields.io/github/stars/wialon/gmqtt)
-   ![license](https://img.shields.io/github/license/wialon/gmqtt)
- * [aiomqtt](https://github.com/mossblaser/aiomqtt) - Wrapper around paho-mqtt.  
-   ![GitHub stars](https://img.shields.io/github/stars/mossblaser/aiomqtt)
-   ![license](https://img.shields.io/github/license/mossblaser/aiomqtt)
- * [mqttools](https://github.com/eerimoq/mqttools) - Own protocol implementation. No dependencies.  
-   ![GitHub stars](https://img.shields.io/github/stars/eerimoq/mqttools)
-   ![license](https://img.shields.io/github/license/eerimoq/mqttools)
- * [aio-mqtt](https://github.com/NotJustAToy/aio-mqtt) - Own protocol implementation. No dependencies.  
-   ![GitHub stars](https://img.shields.io/github/stars/NotJustAToy/aio-mqtt)
-   ![license](https://img.shields.io/github/license/NotJustAToy/aio-mqtt)
+- [hbmqtt](https://github.com/beerfactory/hbmqtt) - Own protocol implementation. Includes a broker.
+  ![GitHub stars](https://img.shields.io/github/stars/beerfactory/hbmqtt)
+  ![license](https://img.shields.io/github/license/beerfactory/hbmqtt)
+- [gmqtt](https://github.com/wialon/gmqtt) - Own protocol implementation. No dependencies.
+  ![GitHub stars](https://img.shields.io/github/stars/wialon/gmqtt)
+  ![license](https://img.shields.io/github/license/wialon/gmqtt)
+- [aiomqtt](https://github.com/mossblaser/aiomqtt) - Wrapper around paho-mqtt.
+  ![GitHub stars](https://img.shields.io/github/stars/mossblaser/aiomqtt)
+  ![license](https://img.shields.io/github/license/mossblaser/aiomqtt)
+- [mqttools](https://github.com/eerimoq/mqttools) - Own protocol implementation. No dependencies.
+  ![GitHub stars](https://img.shields.io/github/stars/eerimoq/mqttools)
+  ![license](https://img.shields.io/github/license/eerimoq/mqttools)
+- [aio-mqtt](https://github.com/NotJustAToy/aio-mqtt) - Own protocol implementation. No dependencies.
+  ![GitHub stars](https://img.shields.io/github/stars/NotJustAToy/aio-mqtt)
+  ![license](https://img.shields.io/github/license/NotJustAToy/aio-mqtt)
 
 This is not an exhaustive list.
 
 ### Honorable mentions
 
- * [trio-paho-mqtt](https://github.com/bkanuka/trio-paho-mqtt) - Trio-based. Wrapper around paho-mqtt.  
-   ![GitHub stars](https://img.shields.io/github/stars/bkanuka/trio-paho-mqtt)
-   ![license](https://img.shields.io/github/license/bkanuka/trio-paho-mqtt)
+- [trio-paho-mqtt](https://github.com/bkanuka/trio-paho-mqtt) - Trio-based. Wrapper around paho-mqtt.
+  ![GitHub stars](https://img.shields.io/github/stars/bkanuka/trio-paho-mqtt)
+  ![license](https://img.shields.io/github/license/bkanuka/trio-paho-mqtt)
 
 ## Requirements
 
@@ -257,12 +257,13 @@ Python 3.7 or later.
 
 There is only a single dependency:
 
- * [paho-mqtt](https://github.com/eclipse/paho.mqtt.python)  
-   ![GitHub stars](https://img.shields.io/github/stars/eclipse/paho.mqtt.python) ![license](https://img.shields.io/github/license/eclipse/paho.mqtt.python)
+- [paho-mqtt](https://github.com/eclipse/paho.mqtt.python)
+  ![GitHub stars](https://img.shields.io/github/stars/eclipse/paho.mqtt.python) ![license](https://img.shields.io/github/license/eclipse/paho.mqtt.python)
 
 ## Note for Windows Users
 
 Since Python 3.8, the default asyncio event loop is the `ProactorEventLoop`. Said loop [doesn't support the `add_reader` method](https://docs.python.org/3/library/asyncio-platforms.html#windows) that is required by asyncio-mqtt. To use asyncio-mqtt, please switch to an event loop that supports the `add_reader` method such as the built-in `SelectorEventLoop`. E.g:
+
 ```python
 # Change to the "Selector" event loop
 asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
@@ -287,5 +288,6 @@ Expect API changes until we reach version `1.0.0`. After `1.0.0`, breaking chang
 ![license](https://img.shields.io/github/license/sbtinstruments/asyncio-mqtt)
 
 Note that the underlying paho-mqtt library is dual-licensed. One of the licenses is the so-called [Eclipse Distribution License v1.0](https://www.eclipse.org/org/documents/edl-v10.php). It is almost word-for-word identical to the [BSD 3-clause License](https://opensource.org/licenses/BSD-3-Clause). The only differences are:
- * One use of "COPYRIGHT OWNER" (EDL) instead of "COPYRIGHT HOLDER" (BSD)
- * One use of "Eclipse Foundation, Inc." (EDL) instead of "copyright holder" (BSD)
+
+- One use of "COPYRIGHT OWNER" (EDL) instead of "COPYRIGHT HOLDER" (BSD)
+- One use of "Eclipse Foundation, Inc." (EDL) instead of "copyright holder" (BSD)


### PR DESCRIPTION
The TLS configuration example in the README fails to run as is because the `ProtocolVersion` is not imported. I added that small change (line 153), relevant PR is #128. I also formatted the `README` with `Prettier` for some more consistency, I hope that's fine with you, otherwise, I'll revert it.