### PR TITLE
AnyIO rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ local_test.py
 .coverage
 coverage.xml
 asyncio_mqtt/_version.py
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-<h1 align="center">Idiomatic asyncio MQTT Client 🙌</h1>
+# This is a re-write based on anyio
+
+Maybe we should fork this to another repo.
+
+I added `anyio_example.py` that you can test with locally. When we agree
+on the API, we can update the rest of this readme.
+
+<h1 align="center">Idiomatic AnyIO MQTT Client 🙌</h1>
 <p align="center">
     <a href="https://github.com/sbtinstruments/asyncio-mqtt/blob/main/LICENSE"><img alt="License: BSD-3-Clause" src="https://img.shields.io/github/license/sbtinstruments/asyncio-mqtt"></a>
     <a href="https://pypi.org/project/asyncio-mqtt"><img alt="PyPI version" src="https://img.shields.io/pypi/v/asyncio-mqtt"></a>

--- a/anyio_example.py
+++ b/anyio_example.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from contextlib import _AsyncGeneratorContextManager
+from random import randrange
+from typing import AsyncGenerator
+
+import anyio
+from paho.mqtt.client import MQTTMessage
+
+from asyncio_mqtt import Client, MqttError
+
+
+async def advanced_example(client: Client) -> None:
+    async with anyio.create_task_group() as tg:
+        # You can create any number of topic filters
+        topic_filters = (
+            "floors/+/humidity",
+            "floors/rooftop/#"
+            # 👉 Try to add more filters!
+        )
+        for topic_filter in topic_filters:
+            # Log all messages that matches the filter
+            manager = client.filtered_messages(topic_filter)
+            template = f'[topic_filter="{topic_filter}"] {{}}'
+            tg.start_soon(log_messages, manager, template)
+
+        # Messages that doesn't match a filter will get logged here
+        tg.start_soon(log_messages, client.unfiltered_messages(), "[unfiltered] {}")
+
+        # Subscribe to topic(s)
+        # 🤔 Note that we subscribe *after* starting the message
+        # loggers. Otherwise, we may miss retained messages.
+        await client.subscribe("my_floors/#")
+
+        # Publish a random value to each of these topics
+        topics = (
+            "my_floors/basement/humidity",
+            "my_floors/rooftop/humidity",
+            "my_floors/rooftop/illuminance",
+            # 👉 Try to add more topics!
+        )
+        tg.start_soon(post_to_topics, client, topics)
+        # End of scope. Wait for everything to complete (or fail due
+        # to, e.g., network errors). All of this happens inside tg.__aexit__.
+
+        # Alternatively, you can cancel the task group after a while.
+        # await anyio.sleep(8)
+        # tg.cancel_scope.cancel()
+
+
+async def post_to_topics(client: Client, topics: list[str]) -> None:
+    while True:
+        for topic in topics:
+            # Send some large packets to test the write loop as well
+            message_len = randrange(10 * 1024**2)  # At most 10 MiB
+            message = bytes(message_len)
+            print(
+                f'[topic="{topic}"] Publishing message of length {len(message) / 1024**2:0.1f} MiB'
+            )
+            await client.publish(topic, message, qos=1)
+            await anyio.sleep(2)
+
+
+async def log_messages(
+    cm: _AsyncGeneratorContextManager[AsyncGenerator[MQTTMessage, None]], template: str
+) -> None:
+    async with cm as messages:
+        async for message in messages:
+            print(template.format(len(message.payload)))
+
+
+async def reconnect_indefinitely(client: Client) -> None:
+    # Run the advanced_example indefinitely. Reconnect automatically
+    # if the connection is lost.
+    reconnect_interval = 3  # [seconds]
+    while True:
+        try:
+            # Note that we can reuse the client over and over.
+            # This fixes issue #27 and (partly) #48
+            async with client:
+                print("Connected to server.")
+                await advanced_example(client)
+            print("Disconnected from server.")
+        except MqttError as error:
+            print(f'Error "{error}". Reconnecting in {reconnect_interval} seconds.')
+        finally:
+            await anyio.sleep(reconnect_interval)
+
+
+async def main() -> None:
+    tg = anyio.create_task_group()
+    async with tg:
+        client = Client(tg, "localhost")
+        await reconnect_indefinitely(client)
+
+
+try:
+    anyio.run(main)
+except KeyboardInterrupt:
+    print("User interrupted the program")

--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -29,6 +29,7 @@ from typing import (
 
 import anyio
 import anyio.abc
+import sniffio
 
 if sys.version_info >= (3, 10):
     from typing import Concatenate, ParamSpec
@@ -587,7 +588,11 @@ class Client:
     def _on_socket_unregister_write(
         self, client: mqtt.Client, userdata: Any, sock: _PahoSocket
     ) -> None:
-        self._event_write = anyio.Event()
+        # Will run out of the event loop if the task group is cancelled
+        try:
+            self._event_write = anyio.Event()
+        except sniffio._impl.AsyncLibraryNotFoundError:
+            pass
 
     def _start_loops(self) -> None:
         assert not self._cancel_scopes, "Loops already started"

--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -289,7 +289,7 @@ class Client:
             # paho.mqtt.Client.connect may raise one of several exceptions.
             # We convert all of them to the common MqttError for user convenience.
             # See: https://github.com/eclipse/paho.mqtt.python/blob/v1.5.0/src/paho/mqtt/client.py#L1770
-            except (socket.error, OSError, mqtt.WebsocketConnectionError) as error:
+            except (OSError, mqtt.WebsocketConnectionError) as error:
                 raise MqttError(str(error))
             self._start_loops()
             # Wait for acknowledgement
@@ -435,7 +435,7 @@ class Client:
 
     async def _cb_and_generator(
         self, stack: AsyncExitStack, *, log_context: str, max_buffer_size: int = 0
-    ) -> Tuple[
+    ) -> tuple[
         Callable[[mqtt.Client, Any, mqtt.MQTTMessage], None],
         AsyncGenerator[mqtt.MQTTMessage, None],
     ]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 lint = ["mypy>=0.982", "flake8>=5.0.4", "types-paho-mqtt>=1.6.0.1"]
 format = ["black>=22.10.0", "isort>=5.10.1"]
-tests = ["pytest>=7.2.0", "pytest-cov>=4.0.0"]
+tests = ["pytest>=7.2.0", "pytest-cov>=4.0.0", "anyio[trio]>=3.6.2"]
 
 [tool.setuptools_scm]
 write_to = "asyncio_mqtt/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ no_strict_concatenate = true # TODO: remove when dropping python 3.7
 filterwarnings = [
     "error",
     "ignore:ssl.PROTOCOL_TLS is deprecated:DeprecationWarning",
+    "ignore:trio.MultiError is deprecated since Trio 0.22.0; use BaseExceptionGroup:trio.TrioDeprecationWarning",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,11 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 requires-python = ">= 3.7"
-dependencies = ["paho-mqtt>=1.6.0", "typing_extensions; python_version<'3.10'"]
+dependencies = [
+    "paho-mqtt>=1.6.0",
+    "anyio>=3.6.2",
+    "typing_extensions; python_version<'3.10'",
+]
 dynamic = ["version"]
 
 [project.urls]
@@ -40,7 +44,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 lint = ["mypy>=0.982", "flake8>=5.0.4", "types-paho-mqtt>=1.6.0.1"]
 format = ["black>=22.10.0", "isort>=5.10.1"]
-tests = ["pytest>=7.2.0", "pytest-cov>=4.0.0", "anyio>=3.6.2"]
+tests = ["pytest>=7.2.0", "pytest-cov>=4.0.0"]
 
 [tool.setuptools_scm]
 write_to = "asyncio_mqtt/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,8 @@ no_strict_concatenate = true # TODO: remove when dropping python 3.7
 filterwarnings = [
     "error",
     "ignore:ssl.PROTOCOL_TLS is deprecated:DeprecationWarning",
-    "ignore:trio.MultiError is deprecated since Trio 0.22.0; use BaseExceptionGroup:trio.TrioDeprecationWarning",
+    # TODO: Remove when using trio >= 22.0
+    "ignore:You seem to already have a custom sys.excepthook handler installed.:RuntimeWarning",
 ]
 
 [tool.coverage.run]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import Any, cast
+from typing import Any, Dict, Tuple, cast
 
 import pytest
 
@@ -18,4 +18,4 @@ else:
 
 @pytest.fixture(params=params)
 def anyio_backend(request: pytest.FixtureRequest) -> tuple[str, dict[str, Any]]:
-    return cast(tuple[str, dict[str, Any]], request.param)
+    return cast(Tuple[str, Dict[str, Any]], request.param)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
 import sys
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
+params = [pytest.param(("trio", {}))]
+if sys.platform == "win32":
+    from asyncio.windows_events import WindowsSelectorEventLoopPolicy
 
-@pytest.fixture
-def anyio_backend() -> tuple[str, dict[str, Any]]:
-    if sys.platform == "win32":
-        from asyncio.windows_events import WindowsSelectorEventLoopPolicy
+    params.append(
+        pytest.param(("asyncio", {"policy": WindowsSelectorEventLoopPolicy()}))
+    )
+else:
+    params.append(pytest.param(("asyncio", {})))
 
-        return ("asyncio", {"policy": WindowsSelectorEventLoopPolicy()})
-    else:
-        return ("asyncio", {})
+
+@pytest.fixture(params=params)
+def anyio_backend(request: pytest.FixtureRequest) -> tuple[str, dict[str, Any]]:
+    return cast(tuple[str, dict[str, Any]], request.param)


### PR DESCRIPTION
BREAKING CHANGE: This breaks support for the old asyncio-based API.
The client behaves differently based on if it runs on `localhost` or `test.mosquitto.org`.
The test suite does not pass.