### PR TITLE
fix: consistently use a user-provided logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Flow Control options to the Client-Constructor. Contributed by [Andreas Heine (@andreasheine)](https://github.com/andreasheine) in [#180](https://github.com/sbtinstruments/asyncio-mqtt/pull/180)
 - Make `Client.pending_calls_threshold` public. Contributed by [Jonathan Plasse (@JonathanPlasse)](https://github.com/JonathanPlasse) in [#185](https://github.com/sbtinstruments/asyncio-mqtt/pull/185)
 
+### Fixed
+
+- Consistently use a user-provided logger. Contributed by [Roman Novatorov @rnovatorov](https://github.com/rnovatorov) in [#176](https://github.com/sbtinstruments/asyncio-mqtt/pull/176)
+
 ## [0.16.1]
 
 ### Fixed

--- a/asyncio_mqtt/client.py
+++ b/asyncio_mqtt/client.py
@@ -317,6 +317,7 @@ class Client:
 
         if logger is None:
             logger = MQTT_LOGGER
+        self._logger = logger
         self._client.enable_logger(logger)
 
         if username is not None:
@@ -485,7 +486,7 @@ class Client:
         self, topic_filter: str, *, queue_maxsize: int = 0
     ) -> AsyncGenerator[AsyncGenerator[mqtt.MQTTMessage, None], None]:
         """Return async generator of messages that match the given filter."""
-        MQTT_LOGGER.warning(
+        self._logger.warning(
             "filtered_messages() is deprecated and will be removed in a future version."
             " Use messages() together with Topic.matches() instead."
         )
@@ -505,7 +506,7 @@ class Client:
         self, *, queue_maxsize: int = 0
     ) -> AsyncGenerator[AsyncGenerator[mqtt.MQTTMessage, None], None]:
         """Return async generator of all messages that are not caught in filters."""
-        MQTT_LOGGER.warning(
+        self._logger.warning(
             "unfiltered_messages() is deprecated and will be removed in a future"
             " version. Use messages() instead."
         )
@@ -560,7 +561,7 @@ class Client:
             try:
                 messages.put_nowait(message)
             except asyncio.QueueFull:
-                MQTT_LOGGER.warning(
+                self._logger.warning(
                     f"[{log_context}] Message queue is full. Discarding message."
                 )
 
@@ -605,7 +606,7 @@ class Client:
             try:
                 messages.put_nowait(message)
             except asyncio.QueueFull:
-                MQTT_LOGGER.warning("Message queue is full. Discarding message.")
+                self._logger.warning("Message queue is full. Discarding message.")
 
         async def _generator() -> AsyncGenerator[Message, None]:
             """Forward all messages from the message queue."""
@@ -655,7 +656,7 @@ class Client:
             # Log a warning if there is a concerning number of pending calls
             pending = len(list(self._pending_calls))
             if pending > self.pending_calls_threshold:
-                MQTT_LOGGER.warning(f"There are {pending} pending publish calls.")
+                self._logger.warning(f"There are {pending} pending publish calls.")
             # Back to the caller (run whatever is inside the with statement)
             yield
         finally:
@@ -732,7 +733,9 @@ class Client:
             if not fut.done():
                 fut.set_result(granted_qos)
         except KeyError:
-            MQTT_LOGGER.error(f'Unexpected message ID "{mid}" in on_subscribe callback')
+            self._logger.error(
+                f'Unexpected message ID "{mid}" in on_subscribe callback'
+            )
 
     def _on_unsubscribe(
         self,
@@ -745,7 +748,7 @@ class Client:
         try:
             self._pending_unsubscribes.pop(mid).set()
         except KeyError:
-            MQTT_LOGGER.error(
+            self._logger.error(
                 f'Unexpected message ID "{mid}" in on_unsubscribe callback'
             )
 
@@ -852,7 +855,7 @@ class Client:
             await self.disconnect()
         except MqttError as error:
             # We tried to be graceful. Now there is no mercy.
-            MQTT_LOGGER.warning(
+            self._logger.warning(
                 f'Could not gracefully disconnect due to "{error}". Forcing'
                 " disconnection."
             )


### PR DESCRIPTION
Client initializer currently accepts a logger as an optional argument. That logger is passed to the underlying paho.mqtt library and then used for logging there. However, there also exists MQTT_LOGGER, which is used internally by asyncio-mqtt. Without looking at the source code it is easy to forget that in order to enable logging both in paho.mqtt and in asyncio-mqtt it is not enough to pass a logger as an argument to Client initializer.

This PR makes asyncio-mqtt use a user-provided logger instead of MQTT_LOGGER for internal logging, so that if user decides to pass a logger to Client constructor, that logger will be used both in paho.mqtt and asyncio-mqtt.